### PR TITLE
Hide placeholder sections on home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -168,7 +168,7 @@
     <!-- Top Banner End -->
 
     <!-- Trusted Section start -->
-    <section class="row_am trusted_section">
+    <section class="row_am trusted_section" style="display:none;">
       <!-- container start -->
       <div class="container">
         <div class="section_title" data-aos="fade-up" data-aos-duration="1500" data-aos-delay="100">
@@ -227,7 +227,7 @@
     <!-- Trusted Section ends -->
 
     <!-- why choose Section Start -->
-    <section class="why_section">
+    <section class="why_section" style="display:none;">
       <div class="why_inner">
         <div class="container">
           <div class="section_title" data-aos="fade-up" data-aos-duration="1500">
@@ -282,7 +282,7 @@
     <!-- why choose Section End -->
 
     <!-- Analyze Section Strat -->
-    <section class="row_am analyze_section">
+    <section class="row_am analyze_section" style="display:none;">
       <div class="container">
         <div class="row">
           <div class="col-md-6">
@@ -320,7 +320,7 @@
     <!-- Analyze Section End -->
 
     <!-- Collaborate Section Strat -->
-    <section class="row_am collaborate_section">
+    <section class="row_am collaborate_section" style="display:none;">
       <div class="container">
         <div class="row">
           <div class="col-md-6">
@@ -368,7 +368,7 @@
     <!-- Analyze Section End -->
 
     <!-- Communication Section Strat -->
-    <section class="row_am communication_section">
+    <section class="row_am communication_section" style="display:none;">
       <div class="container">
         <div class="row">
           <div class="col-md-6">
@@ -402,7 +402,7 @@
     <!-- Communication Section End -->
 
     <!-- Advance Feature-section-Start  -->
-    <section class="row_am advance_feature_section" id="getstarted">
+    <section class="row_am advance_feature_section" id="getstarted" style="display:none;">
       <!-- container start -->
       <div class="container">
         <div class="advance_feature_inner" data-aos="fade-in" data-aos-duration="1500" data-aos-delay="100">
@@ -473,7 +473,7 @@
     <!-- Download-Free-App-section-end  -->
 
     <!-- Powerful solution for your business Section Start -->
-    <section class="powerful_solution" data-aos="fade-in" data-aos-duration="1000">
+    <section class="powerful_solution" style="display:none;" data-aos="fade-in" data-aos-duration="1000">
       <div class="dotes_anim_bloack">
         <div class="dots dotes_1"></div>
         <div class="dots dotes_2"></div>
@@ -595,7 +595,7 @@
     <!-- Integrations Section End -->
 
     <!-- What our customer says Section Start -->
-      <section class="customer_section">
+      <section class="customer_section" style="display:none;">
         <div class="coustomer_block" data-aos="fade-up" data-aos-duration="1000">
           <div class="section_title" data-aos="fade-in" data-aos-duration="1000">
             <h2>Our users love Applash</h2>
@@ -677,7 +677,7 @@
     </section>
 
         <!-- Pricing-Section -->
-    <section class="row_am pricing_section service_list_ps" id="pricing">
+    <section class="row_am pricing_section service_list_ps" id="pricing" style="display:none;">
       <div class="container">
         <div class="section_title" data-aos="fade-up" data-aos-duration="1500">
           <h2>Simple pricing for every project</h2>
@@ -849,7 +849,7 @@
       <!-- FAQ-Section end -->
 
     <!-- Interface overview-Section start -->
-    <section class="row_am interface_section">
+    <section class="row_am interface_section" style="display:none;">
         <div class="section_title" data-aos="fade-up" data-aos-duration="1500" data-aos-delay="300">
           <h2>Interface overview</h2>
           <p>Preview how your web app looks as a native mobile app across pages.</p>
@@ -901,7 +901,7 @@
 
 
     <!-- Start Your Free Trial Section Start -->
-    <section class="free_trial_section" data-aos="fade-in" data-aos-duration="1500">
+    <section class="free_trial_section" style="display:none;" data-aos="fade-in" data-aos-duration="1500">
       <div class="free_inner">
 
         <div class="text">
@@ -949,7 +949,7 @@
 
 
     <!-- Story-Section-Start -->
-    <section class="row_am latest_story" id="blog">
+    <section class="row_am latest_story" id="blog" style="display:none;">
       <!-- container start -->
       <div class="container">
           <div class="section_title" data-aos="fade-in" data-aos-duration="1500" data-aos-delay="100">


### PR DESCRIPTION
## Summary
- hide placeholder content on home page by setting relevant sections to `display: none`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d73265f883308d651fda3542bf48