### PR TITLE
Make home page a single landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,85 +56,7 @@
         </div>
       </div>
 
-      <!-- Header Start -->
-      <header class="fixed">
-        <!-- container start -->
-        <div class="container">
-          <!-- navigation bar -->
-          <nav class="navbar navbar-expand-lg" hidden="true">
-            <a class="navbar-brand" href="index.html">
-              <img src="images/logo.png" alt="image">
-            </a>
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
-              aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-              <span class="navbar-toggler-icon">
-                <!-- <i class="icofont-navigation-menu ico_menu"></i> -->
-                <div class="toggle-wrap">
-                  <span class="toggle-bar"></span>
-                </div>
-              </span>
-            </button>
-
-            <div class="collapse navbar-collapse" id="navbarSupportedContent">
-              <ul class="navbar-nav ml-auto">
-                <li class="nav-item active">
-                  <a class="nav-link" href="index.html">Home</a>
-                </li>
-                <li class="nav-item">
-                  <a class="nav-link" href="about-us.html">About us</a>
-                </li>
-                <li class="nav-item">
-                  <a class="nav-link" href="testimonial.html">Testimonial</a>
-                </li>
-                <!-- secondery menu start -->
-                <li class="nav-item has_dropdown">
-                  <a class="nav-link" href="#">Services</a>
-                  <span class="drp_btn"><i class="icofont-rounded-down"></i></span>
-                  <div class="sub_menu">
-                    <ul>
-                      <li><a href="service-list-1.html">Service List 1</a></li>
-                      <li><a href="service-list-2.html">Service List 2</a></li>
-                      <li><a href="service-detail.html">Service Details </a></li>
-                    </ul>
-                  </div>
-                </li>
-                <li class="nav-item has_dropdown">
-                  <a class="nav-link" href="#">Blog </a>
-                  <span class="drp_btn"><i class="icofont-rounded-down"></i></span>
-                  <div class="sub_menu">
-                    <ul>
-                      <li><a href="blog-list.html">Blog List</a></li>
-                      <li><a href="blog-detail.html">Single Blog</a></li>
-                    </ul>
-                  </div>
-                </li>
-                <li class="nav-item has_dropdown">
-                  <a class="nav-link" href="#">Pages </a>
-                  <span class="drp_btn"><i class="icofont-rounded-down"></i></span>
-                  <div class="sub_menu">
-                    <ul>
-                      <li><a href="pricing.html">Pricing </a></li>
-                      <li><a href="sign-in.html">Sign In </a></li>
-                      <li><a href="sign-up.html">Sign Up </a></li>
-                      <li><a href="error.html">Error 404 </a></li>
-                      <li><a href="faq.html">Faq </a></li>
-                    </ul>
-                  </div>
-                </li>
-                <!-- secondery menu end -->
-                <li class="nav-item">
-                  <a class="nav-link" href="contact-us.html">Contact</a>
-                </li>
-                <li class="nav-item">
-                  <a class="nav-link dark_btn" href="https://applash.online">TRY IT FREE <i class="icofont-arrow-right"></i></a>
-                </li>
-              </ul>
-            </div>
-          </nav>
-          <!-- navigation end -->
-        </div>
-        <!-- container end -->
-      </header>
+        <!-- Header intentionally removed for single-page landing -->
 
       <!-- Banner-Section-Start -->
       <section class="banner_section">
@@ -679,7 +601,7 @@
           <span><i class="icofont-star"></i></span>
           <span><i class="icofont-star"></i></span>
         </div>
-        <p><span>5.0 / 5.0 -</span> <a href="testimonial.html">3689 Total User Reviews <i class="icofont-arrow-right"></i></a></p>
+          <p><span>5.0 / 5.0 -</span> 3689 Total User Reviews</p>
       </div>
     </section>
 
@@ -1079,33 +1001,7 @@
                 </div>
               </div>
 
-              <!-- footer link 2 -->
-              <div class="col-lg-2 col-md-6 col-12">
-                <div class="links">
-                  <h3>Useful Links</h3>
-                  <ul>
-                    <li><a href="index.html">Home</a></li>
-                    <li><a href="about-us.html">About us</a></li>
-                    <li><a href="service-list-1.html">Services</a></li>
-                    <li><a href="service-detail.html">Service Detail</a></li>
-                    <li><a href="blog-list.html">Blog</a></li>
-                  </ul>
-                </div>
-              </div>
-
-              <!-- footer link 3 -->
-              <div class="col-lg-3 col-md-6 col-12">
-                <div class="links">
-                  <h3>Help & Suport</h3>
-                  <ul>
-                    <li><a href="contact-us.html">Contact us</a></li>
-                    <li><a href="faq.html">FAQs</a></li>
-                    <li><a href="#">How it works</a></li>
-                    <li><a href="#">Terms & conditions</a></li>
-                    <li><a href="#">Privacy policy</a></li>
-                  </ul>
-                </div>
-              </div>
+                <!-- footer links removed for single-page landing -->
 
               <!-- footer link 4 -->
               <div class="col-lg-3 col-md-6 col-12">
@@ -1209,6 +1105,13 @@
   <script src="js/main.js"></script>
   <script src="https://unpkg.com/@lottiefiles/dotlottie-wc@0.6.2/dist/dotlottie-wc.js" type="module"></script>
 
+
+  <script>
+    window.blandSettings = {
+      widget_id: "7e77a255-e781-49c1-9b0a-e17fcdc6b479",
+    };
+  </script>
+  <script src="https://widget.bland.ai/loader.js" defer></script>
 
 </body>
 


### PR DESCRIPTION
## Summary
- Remove navigation and footer links to internal pages for a one-page landing experience
- Strip testimonial link and other internal anchors
- Embed Bland.ai chat widget on landing page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2bc48adac8330985794b546d68c4a