### PR TITLE
Move Bland.ai script to header of homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,13 @@
   <!-- Favicon -->
   <link rel="shortcut icon" href="images/favicon.png" type="image/x-icon">
 
+  <script>
+    window.blandSettings = {
+      widget_id: "7e77a255-e781-49c1-9b0a-e17fcdc6b479",
+    };
+  </script>
+  <script src="https://widget.bland.ai/loader.js" defer></script>
+
 </head>
 
 <body>
@@ -1104,14 +1111,6 @@
   <!-- main-js-Link -->
   <script src="js/main.js"></script>
   <script src="https://unpkg.com/@lottiefiles/dotlottie-wc@0.6.2/dist/dotlottie-wc.js" type="module"></script>
-
-
-  <script>
-    window.blandSettings = {
-      widget_id: "7e77a255-e781-49c1-9b0a-e17fcdc6b479",
-    };
-  </script>
-  <script src="https://widget.bland.ai/loader.js" defer></script>
 
 </body>
 


### PR DESCRIPTION
## Summary
- relocate Bland.ai widget script from page footer to document head for earlier loading on the homepage

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2ecfa84f083308a66edf99257a2e4