### PR TITLE
feat: update marketing copy for Applash

### DIFF
--- a/components/cta.tsx
+++ b/components/cta.tsx
@@ -15,11 +15,11 @@ export const CTA = () => {
       <Container className="flex flex-col md:flex-row justify-between items-center w-full px-8">
         <div className="flex flex-col">
           <motion.h2 className="text-white text-xl text-center md:text-left md:text-3xl font-bold mx-auto md:mx-0 max-w-xl ">
-            Get started today with Proactiv to kickstart your marketing efforts
+            Start building mobile apps from your web app with Applash today
           </motion.h2>
           <p className="max-w-md mt-8 text-center md:text-left text-sm md:text-base mx-auto md:mx-0 text-neutral-400">
-            Proactiv houses the best in class software tools to kickstart your
-            marketing journey. Join 127,000+ other users to get started.
+            Applash converts your web app into native mobile apps and ships updates instantly.
+            Join thousands of developers launching on the App Store and Google Play faster.
           </p>
           <FeaturedImages
             textClassName="lg:text-left text-center"
@@ -29,7 +29,7 @@ export const CTA = () => {
           />
         </div>
         <Button className="flex space-x-2 items-center group !text-lg">
-          <span>Book a demo</span>
+          <span>Try Applash free</span>
           <HiArrowRight className="text-black group-hover:translate-x-1 stroke-[1px] h-3 w-3 mt-0.5 transition-transform duration-200" />
         </Button>
       </Container>

--- a/components/faqs.tsx
+++ b/components/faqs.tsx
@@ -6,63 +6,63 @@ import { Heading } from "./heading";
 const questions = [
   {
     id: 1,
-    title: "What is Proactic?",
+    title: "What is Applash?",
     description:
-      "Proactic is a social media marketing automation tool designed to help businesses streamline their social media efforts.",
+      "Applash is a platform that converts your existing web application into fully featured iOS and Android apps.",
   },
   {
     id: 2,
-    title: "How does Proactic work?",
+    title: "How does Applash convert my web app to mobile?",
     description:
-      "Proactic automates the process of scheduling, posting, and analyzing social media content across multiple platforms.",
+      "Applash wraps your web app in a native container and generates installable packages without requiring additional code.",
   },
   {
     id: 3,
-    title: "Which social media platforms does Proactic support?",
+    title: "Which platforms are supported?",
     description:
-      "Proactic supports popular social media platforms such as Facebook, Twitter, Instagram, LinkedIn, and more.",
+      "Applash builds native apps for both the Apple App Store and Google Play Store.",
   },
   {
     id: 4,
-    title: "Can I schedule posts in advance with Proactic?",
+    title: "Do I need to maintain separate codebases?",
     description:
-      "Yes, Proactic allows you to schedule posts in advance, ensuring your content is published at the optimal times.",
+      "No. Keep your web code as the single source of truth and Applash handles the mobile builds for you.",
   },
   {
     id: 5,
-    title: "Does Proactic provide analytics?",
+    title: "Can I send push notifications?",
     description:
-      "Proactic offers detailed analytics to help you track the performance of your social media campaigns and make data-driven decisions.",
+      "Yes, Applash includes built-in push notification support to engage your users.",
   },
   {
     id: 6,
-    title: "Is Proactic suitable for small businesses?",
+    title: "Does Applash work offline?",
     description:
-      "Yes, Proactic is designed to be user-friendly and scalable, making it suitable for businesses of all sizes.",
+      "Applash adds offline caching so your app remains usable even without an internet connection.",
   },
   {
     id: 7,
-    title: "Can I collaborate with my team on Proactic?",
+    title: "How are updates handled?",
     description:
-      "Proactic includes collaboration features that allow team members to work together on social media campaigns.",
+      "Deploy updates to your web app and Applash automatically delivers them to your mobile users.",
   },
   {
     id: 8,
-    title: "Does Proactic offer customer support?",
+    title: "Is there a free trial?",
     description:
-      "Yes, Proactic provides customer support to assist you with any questions or issues you may encounter.",
+      "Yes, you can try Applash for free and generate your first mobile build in minutes.",
   },
   {
     id: 9,
-    title: "Is there a free trial available for Proactic?",
+    title: "How can I track user analytics?",
     description:
-      "Proactic offers a free trial so you can explore its features and see how it can benefit your social media marketing efforts.",
+      "Applash provides in-app analytics to monitor installs, sessions, and engagement.",
   },
   {
     id: 10,
-    title: "How can I get started with Proactic?",
+    title: "How do I get started?",
     description:
-      "To get started with Proactic, simply sign up on our website and follow the onboarding process to set up your account.",
+      "Sign up on our website and upload your web app URL to create your first mobile app with Applash.",
   },
 ];
 

--- a/components/features/index.tsx
+++ b/components/features/index.tsx
@@ -24,18 +24,16 @@ export const Features = () => {
         <FeatureIconContainer className="flex justify-center items-center overflow-hidden">
           <FaBolt className="h-6 w-6 text-cyan-500" />
         </FeatureIconContainer>
-        <Heading className="pt-4">Automate your social media</Heading>
+        <Heading className="pt-4">Launch mobile apps from your web app</Heading>
         <Subheading>
-          Proactiv houses a rich set of features to automate your marketing
-          efforts across all social medias
+          Applash includes everything you need to convert your existing web application into polished iOS and Android apps.
         </Subheading>
 
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-2 py-10">
           <Card className="lg:col-span-2">
-            <CardTitle>Add multiple websites in the same app</CardTitle>
+            <CardTitle>One codebase, multiple platforms</CardTitle>
             <CardDescription>
-              With our AI-powered platform, you can post to multiple platforms
-              at once, saving you time and effort.
+              Manage your web app in one place and Applash packages it into native iOS and Android apps automatically.
             </CardDescription>
             <CardSkeletonContainer>
               <SkeletonOne />
@@ -45,19 +43,18 @@ export const Features = () => {
             <CardSkeletonContainer className="max-w-[16rem] mx-auto">
               <SkeletonTwo />
             </CardSkeletonContainer>
-            <CardTitle>Analytics for everything</CardTitle>
+            <CardTitle>Native device access</CardTitle>
             <CardDescription>
-              Check analytics, track your posts, and get insights into your
-              audience.
+              Tap into camera, geolocation, file storage and more using simple web APIs.
             </CardDescription>
           </Card>
           <Card>
             <CardSkeletonContainer>
               <SkeletonThree />
             </CardSkeletonContainer>
-            <CardTitle>Publish Anywhere</CardTitle>
+            <CardTitle>Offline support</CardTitle>
             <CardDescription>
-              Proactiv uses AI to help you create engaging content.
+              Give users a seamless experience even without an internet connection.
             </CardDescription>
           </Card>
           <Card>
@@ -67,19 +64,18 @@ export const Features = () => {
             >
               <SkeletonFour />
             </CardSkeletonContainer>
-            <CardTitle>Native Features</CardTitle>
+            <CardTitle>Push notifications</CardTitle>
             <CardDescription>
-              Proactive can integrate with Zapier, Slack and every other popular
-              integration tools.
+              Engage your audience with real‑time push notifications and in‑app messages.
             </CardDescription>
           </Card>
           <Card>
             <CardSkeletonContainer>
               <SkeletonFive />
             </CardSkeletonContainer>
-            <CardTitle>Know your audience</CardTitle>
+            <CardTitle>App Store ready</CardTitle>
             <CardDescription>
-              Based on your audience, create funnels and drive more traffic.
+              Generate signed builds for the Apple App Store and Google Play in minutes.
             </CardDescription>
           </Card>
         </div>

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -48,11 +48,11 @@ export const Hero = () => {
           as="h1"
           className="text-4xl md:text-4xl lg:text-8xl font-semibold max-w-6xl mx-auto text-center mt-6 relative z-10  py-6"
         >
-          Transform Your Marketing with Proactiv
+          Convert Web Apps to Mobile with Applash
         </Heading>
         <Subheading className="text-center mt-2 md:mt-6 text-base md:text-xl text-muted dark:text-muted-dark max-w-3xl mx-auto relative z-10">
-          Automate Campaigns, Engage Audiences, and Boost Lead Generation with
-          Our All-in-One Marketing Solution
+          Applash instantly turns your web application into native iOS and Android apps.
+          Reach more users, send push notifications, and publish updates from a single codebase.
         </Subheading>
         <FeaturedImages
           textClassName="lg:text-left text-center"
@@ -61,7 +61,7 @@ export const Hero = () => {
         />
         <div className="flex items-center gap-4 justify-center my-10 relative z-10">
           <Button className="flex space-x-2 items-center group !text-lg">
-            <span>Book a demo</span>{" "}
+            <span>Get started free</span>{" "}
             <HiArrowRight className="text-black group-hover:translate-x-1 stroke-[1px] h-3 w-3 mt-0.5 transition-transform duration-200" />
           </Button>
         </div>

--- a/components/pricing-grid.tsx
+++ b/components/pricing-grid.tsx
@@ -2,7 +2,6 @@
 import React, { useState } from "react";
 import { Container } from "./container";
 import { IconCheck } from "@tabler/icons-react";
-import { CustomLink } from "./custom-link";
 import { Button } from "./button";
 import { cn } from "@/lib/utils";
 import Balancer from "react-wrap-balancer";
@@ -18,15 +17,9 @@ export const PricingGrid = () => {
       monthlyPrice: 0,
       yearlyPrice: 0,
       features: [
-        "Access to all tools for 14 days",
+        "Convert one web app to mobile",
         "No credit card required",
-        "Community Support",
-        <span key="access">
-          Access to{" "}
-          <CustomLink href="https://ui.aceternity.com">
-            Aceternity UI
-          </CustomLink>
-        </span>,
+        "Community support",
       ],
       onClick: () => {
         console.log("clicked");
@@ -40,21 +33,10 @@ export const PricingGrid = () => {
       yearlyPrice: 100,
       features: [
         "Everything in Hobby +",
-        "Access to Proactiv AI",
-        "Priority tools access",
-        <span key="access">
-          Support for{" "}
-          <CustomLink href="https://algochurn.com">Slack</CustomLink> and{" "}
-          <CustomLink href="https://twitter.com/mannupaaji">Twitter</CustomLink>
-        </span>,
+        "Push notifications",
+        "App Store and Play Store builds",
         "Priority support",
-        "99.67% Uptime SLA",
-        <span key="access">
-          Access to{" "}
-          <CustomLink href="https://ui.aceternity.com/templates">
-            Aceternity UI Templates
-          </CustomLink>
-        </span>,
+        "99.9% uptime SLA",
       ],
       onClick: () => {
         console.log("clicked");
@@ -67,21 +49,11 @@ export const PricingGrid = () => {
       monthlyPrice: 30,
       yearlyPrice: 150,
       features: [
-        "Everything in Starter + ",
-        "Access to our dev team",
-        "Coffee with the CEO",
-        <span key="access">
-          Access to{" "}
-          <CustomLink href="https://ui.aceternity.com">
-            Aceternity UI
-          </CustomLink>
-        </span>,
-        "Request tools",
+        "Everything in Starter +",
         "Advanced analytics",
-        "Customizable dashboards",
+        "Unlimited push notifications",
         "24/7 customer support",
-        "Unlimited data storage",
-        "Enhanced security features",
+        "Enhanced security",
       ],
       featured: true,
       onClick: () => {
@@ -95,11 +67,11 @@ export const PricingGrid = () => {
       monthlyPrice: 0,
       yearlyPrice: 0,
       features: [
-        "Everything in Pro + ",
-        "HIPAA and SOC2 compliance",
-        "Bulk email support",
-        "Customizable dashboards",
-        "24/7 customer support",
+        "Everything in Pro +",
+        "Custom integrations",
+        "Dedicated account manager",
+        "SLA & compliance support",
+        "24/7 priority support",
       ],
       onClick: () => {
         console.log("clicked");

--- a/components/tools.tsx
+++ b/components/tools.tsx
@@ -18,9 +18,9 @@ export const Tools = () => {
   const content = [
     {
       icon: <IconMailForward className="h-8 w-8 text-secondary" />,
-      title: "Email Automation",
+      title: "Instant packaging",
       description:
-        "With our best in class email automation, you can automate your entire emailing process.",
+        "Drop in your web app URL and Applash wraps it into installable mobile apps in minutes.",
       content: (
         <ImageContainer>
           <BlurImage
@@ -35,9 +35,9 @@ export const Tools = () => {
     },
     {
       icon: <IconSocial className="h-8 w-8 text-secondary" />,
-      title: "Cross Platform Marketing",
+      title: "Push notification dashboard",
       description:
-        "With our cross platform marketing, you can reach your audience on all the platforms they use.",
+        "Send targeted push notifications and in-app messages without touching native code.",
       content: (
         <ImageContainer>
           <BlurImage
@@ -52,9 +52,9 @@ export const Tools = () => {
     },
     {
       icon: <IconTerminal className="h-8 w-8 text-secondary" />,
-      title: "Managed CRM",
+      title: "Built-in analytics",
       description:
-        "With our managed CRM, you can manage your leads and contacts in one place.",
+        "Track installs, sessions and engagement for every mobile build right from your Applash dashboard.",
       content: (
         <ImageContainer>
           <BlurImage
@@ -69,9 +69,9 @@ export const Tools = () => {
     },
     {
       icon: <IconTerminal className="h-8 w-8 text-secondary" />,
-      title: "Apps Automation",
+      title: "Automated updates",
       description:
-        "We have cloned zapier and built our very own apps automation platform.",
+        "Ship fixes and new features to your mobile users the moment you deploy to the web.",
       content: (
         <ImageContainer>
           <BlurImage
@@ -128,9 +128,9 @@ export const Tools = () => {
         <FeatureIconContainer className="flex justify-center items-center overflow-hidden">
           <IconTool className="h-6 w-6 text-cyan-500" />
         </FeatureIconContainer>
-        <Heading className="mt-4">Perfect set of tools</Heading>
+        <Heading className="mt-4">All the tools to manage your mobile apps</Heading>
         <Subheading>
-          Proactiv comes with perfect tools for the perfect jobs out there.
+          Applash provides a full toolkit for packaging, publishing and growing your mobile presence.
         </Subheading>
       </div>
       <StickyScroll content={content} />


### PR DESCRIPTION
## Summary
- replace placeholder marketing text with SEO-focused copy for Applash
- highlight web-to-mobile conversion features across hero, features, tools, CTA, FAQs, and pricing sections

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c50b92ed188330a5ca3aeb2defd0b6