### PR TITLE
Fix OpenAI logo SVG markup

### DIFF
--- a/components/icons/illustrations.tsx
+++ b/components/icons/illustrations.tsx
@@ -323,7 +323,41 @@ export const OpenAILogo = ({ className }: { className?: string }) => {
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <defs> <linearGradient x1="3.9517088%" y1="26.9930287%" x2="75.8970734%" y2="52.9192657%" id="linearGradient-1"> <stop stop-color="#000000" offset="0%"> </stop> <stop stop-color="#000000" stop-opacity="0" offset="100%"> </stop> </linearGradient> </defs> <g> <polygon fill="#47C5FB" points="157.665785 0.000549356223 0.000549356223 157.665785 48.8009614 206.466197 255.267708 0.000549356223"> </polygon> <polygon fill="#47C5FB" points="156.567183 145.396793 72.1487107 229.815265 121.132608 279.530905 169.842925 230.820587 255.267818 145.396793"> </polygon> <polygon fill="#00569E" points="121.133047 279.531124 158.214592 316.61267 255.267159 316.61267 169.842266 230.820807"> </polygon> <polygon fill="#00B5F8" points="71.5995742 230.364072 120.401085 181.562561 169.842046 230.821136 121.132827 279.531454"> </polygon> <polygon fill-opacity="0.8" fill="url(#linearGradient-1)" points="121.132827 279.531454 161.692896 266.072227 165.721875 234.941308"> </polygon>
+      <defs>
+        <linearGradient
+          x1="3.9517088%"
+          y1="26.9930287%"
+          x2="75.8970734%"
+          y2="52.9192657%"
+          id="linearGradient-1"
+        >
+          <stop stopColor="#000000" offset="0%" />
+          <stop stopColor="#000000" stopOpacity="0" offset="100%" />
+        </linearGradient>
+      </defs>
+      <g>
+        <polygon
+          fill="#47C5FB"
+          points="157.665785 0.000549356223 0.000549356223 157.665785 48.8009614 206.466197 255.267708 0.000549356223"
+        />
+        <polygon
+          fill="#47C5FB"
+          points="156.567183 145.396793 72.1487107 229.815265 121.132608 279.530905 169.842925 230.820587 255.267818 145.396793"
+        />
+        <polygon
+          fill="#00569E"
+          points="121.133047 279.531124 158.214592 316.61267 255.267159 316.61267 169.842266 230.820807"
+        />
+        <polygon
+          fill="#00B5F8"
+          points="71.5995742 230.364072 120.401085 181.562561 169.842046 230.821136 121.132827 279.531454"
+        />
+        <polygon
+          fill="url(#linearGradient-1)"
+          fillOpacity="0.8"
+          points="121.132827 279.531454 161.692896 266.072227 165.721875 234.941308"
+        />
+      </g>
     </svg>
   );
 };


### PR DESCRIPTION
## Summary
- convert the OpenAI logo SVG markup to valid JSX with proper formatting
- close the group element and camelCase SVG attribute names to satisfy the TypeScript parser

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8a216f5c08330a6d0fabe195ff5c6