### PR TITLE
Link primary CTA buttons to login portal

### DIFF
--- a/components/cta.tsx
+++ b/components/cta.tsx
@@ -28,7 +28,11 @@ export const CTA = () => {
             showStars
           />
         </div>
-        <Button className="flex space-x-2 items-center group !text-lg">
+        <Button
+          className="flex space-x-2 items-center group !text-lg"
+          as="a"
+          href="https://applash.online"
+        >
           <span>Try Applash free</span>
           <HiArrowRight className="text-black group-hover:translate-x-1 stroke-[1px] h-3 w-3 mt-0.5 transition-transform duration-200" />
         </Button>

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -1,7 +1,6 @@
 "use client";
 import React, { useRef } from "react";
 import { MotionValue, motion, useScroll, useTransform } from "motion/react";
-import { useRouter } from "next/navigation";
 import { Button } from "./button";
 import { HiArrowRight } from "react-icons/hi2";
 import Image from "next/image";
@@ -13,8 +12,6 @@ import { FeaturedImages } from "./featured-images";
 import Beam from "./beam";
 import { ArcadeEmbed } from "./arcade";
 export const Hero = () => {
-  const router = useRouter();
-
   const containerRef = useRef<any>(null);
   const { scrollYProgress } = useScroll({
     target: containerRef,
@@ -61,7 +58,11 @@ export const Hero = () => {
           showStars
         />
         <div className="flex items-center gap-4 justify-center my-10 relative z-10">
-          <Button className="flex space-x-2 items-center group !text-lg">
+          <Button
+            className="flex space-x-2 items-center group !text-lg"
+            as="a"
+            href="https://applash.online"
+          >
             <span>Get started free</span>{" "}
             <HiArrowRight className="text-black group-hover:translate-x-1 stroke-[1px] h-3 w-3 mt-0.5 transition-transform duration-200" />
           </Button>

--- a/components/navbar/desktop-navbar.tsx
+++ b/components/navbar/desktop-navbar.tsx
@@ -69,7 +69,7 @@ export const DesktopNavbar = ({ navItems }: Props) => {
         </div>
       </div>
       <div className="flex space-x-2 items-center">
-        <Button variant="simple" as={Link} href="/register">
+        <Button variant="simple" as="a" href="https://applash.online">
           Register
         </Button>
         <Button>Book a demo</Button>

--- a/components/navbar/mobile-navbar.tsx
+++ b/components/navbar/mobile-navbar.tsx
@@ -84,8 +84,8 @@ export const MobileNavbar = ({ navItems }: any) => {
             <Button>Book a demo</Button>
             <Button
               variant="simple"
-              as={Link}
-              href="/register"
+              as="a"
+              href="https://applash.online"
               onClick={() => {
                 setOpen(false);
               }}

--- a/components/pricing-grid.tsx
+++ b/components/pricing-grid.tsx
@@ -19,9 +19,7 @@ export const PricingGrid = () => {
         "No credit card required",
         "Community support",
       ],
-      onClick: () => {
-        console.log("clicked");
-      },
+      href: "https://applash.online",
       ctaText: "Get Started",
     },
     {
@@ -35,9 +33,7 @@ export const PricingGrid = () => {
         "Priority support",
         "99.9% uptime SLA",
       ],
-      onClick: () => {
-        console.log("clicked");
-      },
+      href: "https://applash.online",
       ctaText: "Get Started",
     },
     {
@@ -52,9 +48,7 @@ export const PricingGrid = () => {
         "Enhanced security",
       ],
       featured: true,
-      onClick: () => {
-        console.log("clicked");
-      },
+      href: "https://applash.online",
       ctaText: "Get Started",
     },
     {
@@ -68,9 +62,7 @@ export const PricingGrid = () => {
         "SLA & compliance support",
         "Contact us for agency pricing",
       ],
-      onClick: () => {
-        console.log("clicked");
-      },
+      href: "https://applash.online",
       ctaText: "Contact us",
     },
   ];
@@ -101,7 +93,8 @@ export const PricingGrid = () => {
             </div>
             <Button
               variant={tier.featured ? "primary" : "muted"}
-              onClick={tier.onClick}
+              as="a"
+              href={tier.href}
               className="mt-4"
             >
               {tier.ctaText}


### PR DESCRIPTION
## Summary
- point the desktop and mobile navigation "Register" button to https://applash.online
- update the hero, CTA, and pricing tier buttons so each directs visitors to the external login page

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9052bd56083309c5d096c71d5dfc2