### PR TITLE
Fix Spline import to avoid async client component

### DIFF
--- a/components/spline-hero-model.tsx
+++ b/components/spline-hero-model.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Spline from "@splinetool/react-spline/next";
+import Spline from "@splinetool/react-spline";
 
 export const SplineHeroModel = () => {
   return (


### PR DESCRIPTION
## Summary
- switch the hero Spline model to use the standard `@splinetool/react-spline` entry point instead of the async Next.js helper
- prevent the React 482 runtime error by rendering the synchronous Spline component inside the client hero wrapper

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68cf2c618ce083309a689fe20ca1d9cb