### PR TITLE
Integrate Typeform popups for marketing CTAs

### DIFF
--- a/components/cta.tsx
+++ b/components/cta.tsx
@@ -7,6 +7,11 @@ import { HiArrowRight } from "react-icons/hi2";
 import { AmbientColor } from "./ambient-color";
 import { Container } from "./container";
 import { FeaturedImages } from "./featured-images";
+import { PopupButton } from "@typeform/embed-react";
+import {
+  TYPEFORM_CONTACT_FORM_ID,
+  TYPEFORM_CTA_MEDIUM,
+} from "@/constants/typeform";
 
 export const CTA = () => {
   return (
@@ -30,8 +35,9 @@ export const CTA = () => {
         </div>
         <Button
           className="flex space-x-2 items-center group !text-lg"
-          as="a"
-          href="/contact"
+          as={PopupButton}
+          id={TYPEFORM_CONTACT_FORM_ID}
+          data-tf-medium={`${TYPEFORM_CTA_MEDIUM}-cta`}
         >
           <span>Book your launch call</span>
           <HiArrowRight className="text-black group-hover:translate-x-1 stroke-[1px] h-3 w-3 mt-0.5 transition-transform duration-200" />

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -10,6 +10,11 @@ import { FeaturedImages } from "./featured-images";
 import Beam from "./beam";
 import { SplineHeroModel } from "./spline-hero-model";
 import { ArcadeEmbed } from "./arcade";
+import { PopupButton } from "@typeform/embed-react";
+import {
+  TYPEFORM_CONTACT_FORM_ID,
+  TYPEFORM_CTA_MEDIUM,
+} from "@/constants/typeform";
 export const Hero = () => {
   const containerRef = useRef<any>(null);
   const { scrollYProgress } = useScroll({
@@ -62,8 +67,9 @@ export const Hero = () => {
         <div className="flex items-center gap-4 justify-center my-10 relative z-10">
           <Button
             className="flex space-x-2 items-center group !text-lg"
-            as="a"
-            href="/contact"
+            as={PopupButton}
+            id={TYPEFORM_CONTACT_FORM_ID}
+            data-tf-medium={`${TYPEFORM_CTA_MEDIUM}-hero`}
           >
             <span>Launch your vata</span>{" "}
             <HiArrowRight className="text-black group-hover:translate-x-1 stroke-[1px] h-3 w-3 mt-0.5 transition-transform duration-200" />

--- a/components/navbar/desktop-navbar.tsx
+++ b/components/navbar/desktop-navbar.tsx
@@ -10,7 +10,11 @@ import {
 } from "motion/react";
 import { cn } from "@/lib/utils";
 import { useState } from "react";
-import { Link } from "next-view-transitions";
+import { PopupButton } from "@typeform/embed-react";
+import {
+  TYPEFORM_CONTACT_FORM_ID,
+  TYPEFORM_CTA_MEDIUM,
+} from "@/constants/typeform";
 
 type Props = {
   navItems: {
@@ -69,10 +73,11 @@ export const DesktopNavbar = ({ navItems }: Props) => {
         </div>
       </div>
       <div className="flex space-x-2 items-center">
-        <Button variant="simple" as="a" href="/register">
-          Sign in
-        </Button>
-        <Button as="a" href="/contact">
+        <Button
+          as={PopupButton}
+          id={TYPEFORM_CONTACT_FORM_ID}
+          data-tf-medium={`${TYPEFORM_CTA_MEDIUM}-navbar-desktop`}
+        >
           Book a launch call
         </Button>
       </div>

--- a/components/navbar/mobile-navbar.tsx
+++ b/components/navbar/mobile-navbar.tsx
@@ -7,6 +7,11 @@ import { IoIosClose } from "react-icons/io";
 import { Button } from "@/components/button";
 import { Logo } from "@/components/logo";
 import { useMotionValueEvent, useScroll } from "motion/react";
+import { PopupButton } from "@typeform/embed-react";
+import {
+  TYPEFORM_CONTACT_FORM_ID,
+  TYPEFORM_CTA_MEDIUM,
+} from "@/constants/typeform";
 
 export const MobileNavbar = ({ navItems }: any) => {
   const [open, setOpen] = useState(false);
@@ -82,23 +87,14 @@ export const MobileNavbar = ({ navItems }: any) => {
           </div>
           <div className="flex flex-row w-full items-start gap-2.5  px-8 py-4 ">
             <Button
-              as="a"
-              href="/contact"
-              onClick={() => {
+              as={PopupButton}
+              id={TYPEFORM_CONTACT_FORM_ID}
+              data-tf-medium={`${TYPEFORM_CTA_MEDIUM}-navbar-mobile`}
+              onClickCapture={() => {
                 setOpen(false);
               }}
             >
               Book a launch call
-            </Button>
-            <Button
-              variant="simple"
-              as="a"
-              href="/register"
-              onClick={() => {
-                setOpen(false);
-              }}
-            >
-              Sign in
             </Button>
           </div>
         </div>

--- a/components/pricing-grid.tsx
+++ b/components/pricing-grid.tsx
@@ -7,6 +7,11 @@ import { cn } from "@/lib/utils";
 import Balancer from "react-wrap-balancer";
 import Beam from "./beam";
 import { Clients } from "./clients";
+import { PopupButton } from "@typeform/embed-react";
+import {
+  TYPEFORM_CONTACT_FORM_ID,
+  TYPEFORM_CTA_MEDIUM,
+} from "@/constants/typeform";
 
 export const PricingGrid = () => {
   const tiers = [
@@ -20,7 +25,6 @@ export const PricingGrid = () => {
         "Inbox visibility for every outreach and escalation",
         "Knowledge hub training included",
       ],
-      href: "/contact",
       ctaText: "Talk to sales",
     },
     {
@@ -34,7 +38,6 @@ export const PricingGrid = () => {
         "Pipeline analytics, CRM syncs, and SLA monitoring",
       ],
       featured: true,
-      href: "/contact",
       ctaText: "Start subscription",
     },
     {
@@ -47,7 +50,6 @@ export const PricingGrid = () => {
         "Private Slack or Teams channel with revenue engineers",
         "Volume pricing and procurement-friendly contracts",
       ],
-      href: "/contact",
       ctaText: "Design your plan",
     },
     {
@@ -60,7 +62,6 @@ export const PricingGrid = () => {
         "Shared inbox permissions across client workspaces",
         "Partner-only reporting and quarterly roadmap previews",
       ],
-      href: "/contact",
       ctaText: "Apply now",
     },
   ];
@@ -91,8 +92,9 @@ export const PricingGrid = () => {
             </div>
             <Button
               variant={tier.featured ? "primary" : "muted"}
-              as="a"
-              href={tier.href}
+              as={PopupButton}
+              id={TYPEFORM_CONTACT_FORM_ID}
+              data-tf-medium={`${TYPEFORM_CTA_MEDIUM}-pricing-${index}`}
               className="mt-4"
             >
               {tier.ctaText}

--- a/constants/typeform.ts
+++ b/constants/typeform.ts
@@ -1,0 +1,4 @@
+export const TYPEFORM_CONTACT_FORM_ID =
+  process.env.NEXT_PUBLIC_TYPEFORM_CONTACT_FORM_ID ?? "V17uKPUK";
+
+export const TYPEFORM_CTA_MEDIUM = "website-cta";

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@tsparticles/engine": "^3.4.0",
         "@tsparticles/react": "^3.0.0",
         "@tsparticles/slim": "^3.4.0",
+        "@typeform/embed-react": "^4.6.0",
         "@types/mdx": "^2.0.13",
         "clsx": "^2.1.1",
         "date-fns": "^3.6.0",
@@ -1522,6 +1523,31 @@
       "integrity": "sha512-5pe/777vPZgzlNBkh8GQ3fjT6273wcwlBeq4UkDA/q6bI867d8W+Fi8yUsqfdiS6B5tKSvVsI8rFrfwjEvW0pg==",
       "dependencies": {
         "@tsparticles/engine": "^3.4.0"
+      }
+    },
+    "node_modules/@typeform/embed": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@typeform/embed/-/embed-5.5.0.tgz",
+      "integrity": "sha512-+JIwsOfok9MjoKsDw8YbQsAZYThKEARK+m/hSZxrU6s5WoZxVnwDsO+O5HyrMtH+kOuNb5kIvQM2lPc0c33c2g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typeform/embed-react": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@typeform/embed-react/-/embed-react-4.6.0.tgz",
+      "integrity": "sha512-PvaCThmPyZCOqnAbqvQ5nLNeUaAAqULxQor9MW7HHmDqoWtPW6RmiPc8Tg0RkPFCANSnlzORFymj5didORn3pA==",
+      "license": "MIT",
+      "dependencies": {
+        "@typeform/embed": "5.5.0",
+        "fast-deep-equal": "^3.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@types/acorn": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@tsparticles/engine": "^3.4.0",
     "@tsparticles/react": "^3.0.0",
     "@tsparticles/slim": "^3.4.0",
+    "@typeform/embed-react": "^4.6.0",
     "@types/mdx": "^2.0.13",
     "clsx": "^2.1.1",
     "date-fns": "^3.6.0",


### PR DESCRIPTION
## Summary
- add a shared Typeform configuration and dependency
- replace marketing CTA buttons with Typeform popups and hide the sign-in button

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5bc1ac334833094c8cac315e68fa2