### PR TITLE
Update skeleton imagery and navbar CTA

### DIFF
--- a/components/Notification.tsx
+++ b/components/Notification.tsx
@@ -2,12 +2,13 @@
 
 import { cn } from "@/lib/utils";
 import { AnimatedList } from "@/components/magicui/animated-list";
+import Image from "next/image";
 
 interface Item {
   name: string;
   description: string;
-  icon: string;
-  color: string;
+  imageSrc: string;
+  imageAlt: string;
   time: string;
 }
 
@@ -16,36 +17,35 @@ let notifications = [
     name: "Payment received",
     description: "$100 Added to account",
     time: "15m ago",
-
-    icon: "💸",
-    color: "#00C9A7",
+    imageSrc: "/images/vatas/square-blue.png",
+    imageAlt: "Blue square notification icon",
   },
   {
     name: "User signed up",
     description: "Magic UI",
     time: "10m ago",
-    icon: "👤",
-    color: "#FFB800",
+    imageSrc: "/images/vatas/square-red.png",
+    imageAlt: "Red square notification icon",
   },
   {
     name: "New message",
     description: "Magic UI",
     time: "5m ago",
-    icon: "💬",
-    color: "#FF3D71",
+    imageSrc: "/images/vatas/square-blue.png",
+    imageAlt: "Blue square notification icon",
   },
   {
     name: "New event",
     description: "Magic UI",
     time: "2m ago",
-    icon: "🗞️",
-    color: "#1E86FF",
+    imageSrc: "/images/vatas/square-red.png",
+    imageAlt: "Red square notification icon",
   },
 ];
 
 notifications = Array.from({ length: 10 }, () => notifications).flat();
 
-const Notification = ({ name, description, icon, color, time }: Item) => {
+const Notification = ({ name, description, imageSrc, imageAlt, time }: Item) => {
   return (
     <figure
       className={cn(
@@ -59,13 +59,14 @@ const Notification = ({ name, description, icon, color, time }: Item) => {
       )}
     >
       <div className="flex flex-row items-center gap-3">
-        <div
-          className="flex size-10 items-center justify-center rounded-2xl"
-          style={{
-            backgroundColor: color,
-          }}
-        >
-          <span className="text-lg">{icon}</span>
+        <div className="relative flex size-10 items-center justify-center overflow-hidden rounded-2xl bg-white/10">
+          <Image
+            src={imageSrc}
+            alt={imageAlt}
+            width={40}
+            height={40}
+            className="h-full w-full object-cover"
+          />
         </div>
         <div className="flex flex-col overflow-hidden">
           <figcaption className="flex flex-row items-center whitespace-pre text-lg font-medium dark:text-white ">

--- a/components/features/skeletons/fifth.tsx
+++ b/components/features/skeletons/fifth.tsx
@@ -9,9 +9,9 @@ export const SkeletonFive = () => {
       <div className="flex absolute inset-0 flex-col group-hover:-translate-y-80 transition duration-200 items-center justify-center">
         <Container>
           <Image
-            src="/avatar.png"
+            src="/images/vatas/square-red.png"
             className="h-16 w-16 rounded-md object-cover"
-            alt="avatar"
+            alt="Red square avatar"
             width="100"
             height="100"
           />
@@ -39,9 +39,9 @@ export const SkeletonFive = () => {
       <div className="flex absolute inset-0 flex-col translate-y-80 group-hover:translate-y-0 transition duration-200 items-center justify-center">
         <Container>
           <Image
-            src="https://images.unsplash.com/photo-1599566150163-29194dcaad36?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=3387&q=80"
+            src="/images/vatas/square-blue.png"
             className="h-16 w-16 rounded-md object-cover"
-            alt="avatar"
+            alt="Blue square avatar"
             width="100"
             height="100"
           />

--- a/components/features/skeletons/fourth.tsx
+++ b/components/features/skeletons/fourth.tsx
@@ -16,11 +16,11 @@ export const SkeletonFour = () => {
         <CircleWithLine />
         <CircleWithLine />
       </div>
-      <Container className="mt-10 ml-4">Enable microphone</Container>
+      <Container className="mt-10 ml-4">Upload Playbooks</Container>
       <Container className="mt-4 ml-10 group-hover:border-secondary transition duration-200 group-hover:scale-[1.02]">
-        Enable camera
+        Link Website
       </Container>
-      <Container className="mt-4 ml-4">Enable geolocation</Container>
+      <Container className="mt-4 ml-4">Type Here</Container>
       <Cursor
         className="top-20 left-40 group-hover:left-32"
         textClassName="group-hover:text-secondary"

--- a/components/navbar/desktop-navbar.tsx
+++ b/components/navbar/desktop-navbar.tsx
@@ -78,7 +78,7 @@ export const DesktopNavbar = ({ navItems }: Props) => {
           id={TYPEFORM_CONTACT_FORM_ID}
           data-tf-medium={`${TYPEFORM_CTA_MEDIUM}-navbar-desktop`}
         >
-          Book a launch call
+          Sign up for beta
         </Button>
       </div>
     </motion.div>

--- a/components/navbar/mobile-navbar.tsx
+++ b/components/navbar/mobile-navbar.tsx
@@ -94,7 +94,7 @@ export const MobileNavbar = ({ navItems }: any) => {
                 setOpen(false);
               }}
             >
-              Book a launch call
+              Sign up for beta
             </Button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- replace the avatars in the fifth feature skeleton with the square-red and square-blue vatas images
- refresh the fourth feature skeleton labels to match the new Upload/Link/Type Here copy
- swap notification list icons for the square vatas artwork and update the navbar button text to "Sign up for beta"

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8246eb8048330928c5528d9f8bf88