### PR TITLE
Align notification animation with escalation flow

### DIFF
--- a/components/Notification.tsx
+++ b/components/Notification.tsx
@@ -14,32 +14,32 @@ interface Item {
 
 let notifications = [
   {
-    name: "Payment received",
-    description: "$100 Added to account",
-    time: "15m ago",
+    name: "Needs context",
+    description: "Ava paused: prospect asked about security review steps.",
+    time: "Just now",
     imageSrc: "/images/vatas/square-blue.png",
-    imageAlt: "Blue square notification icon",
+    imageAlt: "Blue square escalation icon",
   },
   {
-    name: "User signed up",
-    description: "Magic UI",
-    time: "10m ago",
+    name: "You replied",
+    description: "Shared the SOC 2 answer and when to involve legal.",
+    time: "1m ago",
     imageSrc: "/images/vatas/square-red.png",
-    imageAlt: "Red square notification icon",
+    imageAlt: "Red square escalation icon",
   },
   {
-    name: "New message",
-    description: "Magic UI",
-    time: "5m ago",
+    name: "Saved for next time",
+    description: "Vata stored your guidance for similar asks.",
+    time: "30m ago",
     imageSrc: "/images/vatas/square-blue.png",
-    imageAlt: "Blue square notification icon",
+    imageAlt: "Blue square escalation icon",
   },
   {
-    name: "New event",
-    description: "Magic UI",
-    time: "2m ago",
+    name: "Conversation resumed",
+    description: "Prospect got their answer. No repeat pings needed.",
+    time: "45m ago",
     imageSrc: "/images/vatas/square-red.png",
-    imageAlt: "Red square notification icon",
+    imageAlt: "Red square escalation icon",
   },
 ];
 

--- a/components/features/index.tsx
+++ b/components/features/index.tsx
@@ -43,18 +43,18 @@ export const Features = () => {
             <CardSkeletonContainer className="max-w-[16rem] mx-auto">
               <SkeletonTwo />
             </CardSkeletonContainer>
-            <CardTitle>Qualification playbooks</CardTitle>
+            <CardTitle>Escalate when stuck</CardTitle>
             <CardDescription>
-              Set ICP rules and scoring so only sales-ready leads ever reach your pipeline.
+              Vatas ping you for context once, save the answer, and handle the next ask on their own.
             </CardDescription>
           </Card>
           <Card>
             <CardSkeletonContainer>
               <SkeletonThree />
             </CardSkeletonContainer>
-            <CardTitle>Escalate when stuck</CardTitle>
+            <CardTitle>Qualification playbooks</CardTitle>
             <CardDescription>
-              Vatas ping you for context once, save the answer, and handle the next ask on their own.
+              Set ICP rules and scoring so only sales-ready leads ever reach your pipeline.
             </CardDescription>
           </Card>
           <Card>


### PR DESCRIPTION
## Summary
- update the notification animation copy to depict a vata escalating for human context and resuming the conversation

## Testing
- Not run (not required)

------
https://chatgpt.com/codex/tasks/task_e_68d88a444c648330afae42613533d567