### PR TITLE
Update homepage copy to be more direct

### DIFF
--- a/app/(marketing)/page.tsx
+++ b/app/(marketing)/page.tsx
@@ -28,8 +28,7 @@ export default function Home() {
         </FeatureIconContainer>
         <Heading className="pt-4">Results-based pricing</Heading>
         <Subheading>
-          Pay only for the qualified opportunities vatas close, with a flat
-          subscription once you pass twenty wins a month.
+          Pay per qualified opportunity. After twenty wins in a month, switch to the flat subscription.
         </Subheading>
         <PricingGrid />
         <FAQs />

--- a/components/clients.tsx
+++ b/components/clients.tsx
@@ -42,7 +42,7 @@ export const Clients = () => {
   return (
     <div className="pt-20 pb-40 h-40">
       <p className="text-neutral-400 text-center mb-4">
-        Revenue teams scaling with Vatas
+        Teams already running vatas in production
       </p>
       <div className="flex justify-center gap-4 max-w-7xl mx-auto relative">
         <div className="absolute inset-0 bg-charcoal grayscale z-40 pointer-events-none [mask-image:_radial-gradient(circle,_transparent_10%,_#000000_100%)]" />

--- a/components/cta.tsx
+++ b/components/cta.tsx
@@ -20,11 +20,11 @@ export const CTA = () => {
       <Container className="flex flex-col md:flex-row justify-between items-center w-full px-8">
         <div className="flex flex-col">
           <motion.h2 className="text-white text-xl text-center md:text-left md:text-3xl font-bold mx-auto md:mx-0 max-w-xl ">
-            Put vatas on your pipeline today
+            Launch your first vata this week
           </motion.h2>
           <p className="max-w-md mt-8 text-center md:text-left text-sm md:text-base mx-auto md:mx-0 text-neutral-400">
-            Connect your channels, upload your knowledge, and let autonomous sellers chase, qualify, and close.
-            Stay in the inbox while vatas handle the busy work.
+            Connect your channels, upload the docs they need, and let the vatas chase, qualify, and hand off meetings.
+            You stay in control from the shared inbox.
           </p>
           <FeaturedImages
             textClassName="lg:text-left text-center"

--- a/components/faqs.tsx
+++ b/components/faqs.tsx
@@ -8,25 +8,25 @@ const questions = [
     id: 1,
     title: "What is Vatas?",
     description:
-      "Vatas is a 24/7 AI sales force that hunts, qualifies, and closes leads across social networks.",
+      "Vatas are autonomous AI sellers that monitor your channels, qualify prospects, and pass meetings to your team.",
   },
   {
     id: 2,
     title: "How do vatas find new leads?",
     description:
-      "Each vata crawls LinkedIn, Reddit, and your inboxes to spot buying signals and book meetings.",
+      "Each vata watches LinkedIn, Reddit, and your inboxes to spot buying signals and book meetings.",
   },
   {
     id: 3,
     title: "What data should I connect?",
     description:
-      "Link your social profiles, storage, analytics, and knowledge bases so vatas learn your business and ideal customers.",
+      "Link your social profiles, storage, analytics, and knowledge bases so vatas understand your business and ideal customers.",
   },
   {
     id: 4,
     title: "How do vatas learn our voice?",
     description:
-      "Upload assets to the knowledge hub, tag personas, and vatas adapt outreach with every conversation.",
+      "Upload assets to the knowledge hub, tag personas, and the vatas adjust outreach with each new conversation.",
   },
   {
     id: 5,
@@ -50,7 +50,7 @@ const questions = [
     id: 8,
     title: "How does pricing work?",
     description:
-      "Pay $50 per qualified lead monthly, or choose the $399/month subscription past twenty wins.",
+      "Pay $50 per qualified lead each month, or move to the $399/month subscription after twenty wins.",
   },
   {
     id: 9,

--- a/components/features/index.tsx
+++ b/components/features/index.tsx
@@ -24,16 +24,16 @@ export const Features = () => {
         <FeatureIconContainer className="flex justify-center items-center overflow-hidden">
           <FaBolt className="h-6 w-6 text-cyan-500" />
         </FeatureIconContainer>
-        <Heading className="pt-4">Everything your AI sellers need to win deals</Heading>
+        <Heading className="pt-4">What the vatas handle day to day</Heading>
         <Subheading>
-          Vatas work every social channel, qualify fit, and only tap you when a human touch is needed.
+          They plug into your channels, qualify prospects, and only escalate when you need to step in.
         </Subheading>
 
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-2 py-10">
           <Card className="lg:col-span-2">
-            <CardTitle>Connect every social account</CardTitle>
+            <CardTitle>Connect your channels</CardTitle>
             <CardDescription>
-              Link LinkedIn, Reddit, Slack, email, and more so vatas jump into warm conversations right away.
+              Link LinkedIn, Reddit, Slack, email, and other sources so vatas join ongoing conversations immediately.
             </CardDescription>
             <CardSkeletonContainer>
               <SkeletonOne />
@@ -43,18 +43,18 @@ export const Features = () => {
             <CardSkeletonContainer className="max-w-[16rem] mx-auto">
               <SkeletonTwo />
             </CardSkeletonContainer>
-            <CardTitle>Escalate when stuck</CardTitle>
+            <CardTitle>Escalate when they need help</CardTitle>
             <CardDescription>
-              Vatas ping you for context once, save the answer, and handle the next ask on their own.
+              When a vata hits a blocker it pings you once, saves the response, and applies it next time.
             </CardDescription>
           </Card>
           <Card>
             <CardSkeletonContainer>
               <SkeletonThree />
             </CardSkeletonContainer>
-            <CardTitle>Qualification playbooks</CardTitle>
+            <CardTitle>Qualification rules</CardTitle>
             <CardDescription>
-              Set ICP rules and scoring so only sales-ready leads ever reach your pipeline.
+              Set ICP rules and scoring so only sales-ready leads enter your pipeline.
             </CardDescription>
           </Card>
           <Card>
@@ -64,18 +64,18 @@ export const Features = () => {
             >
               <SkeletonFour />
             </CardSkeletonContainer>
-            <CardTitle>Knowledge-fed conversations</CardTitle>
+            <CardTitle>Knowledge-fed outreach</CardTitle>
             <CardDescription>
-              Sync docs, call recordings, and analytics so every outreach stays on-message and current.
+              Sync docs, call recordings, and analytics so every message matches your latest positioning.
             </CardDescription>
           </Card>
           <Card>
             <CardSkeletonContainer>
               <SkeletonFive />
             </CardSkeletonContainer>
-            <CardTitle>Pay-for-results billing</CardTitle>
+            <CardTitle>Pay for outcomes</CardTitle>
             <CardDescription>
-              Get one monthly invoice tied to qualified deals, starting at $50 per lead.
+              Receive one monthly invoice tied to qualified deals, starting at $50 per lead.
             </CardDescription>
           </Card>
         </div>

--- a/components/pricing-grid.tsx
+++ b/components/pricing-grid.tsx
@@ -17,24 +17,24 @@ export const PricingGrid = () => {
   const tiers = [
     {
       title: "Pay for Results",
-      description: "Only pay when a vata closes a qualified lead",
+      description: "You pay only when a vata delivers a qualified lead",
       priceText: "$50 per qualified lead",
       features: [
         "No platform fees or retainers",
         "Verified buyer identity, intent, and contact info",
-        "Inbox visibility for every outreach and escalation",
-        "Knowledge hub training included",
+        "Full inbox visibility for every outreach and escalation",
+        "Knowledge hub setup included",
       ],
       ctaText: "Talk to sales",
     },
     {
       title: "Growth Subscription",
-      description: "Predictable pricing for teams closing 20+ new deals each month",
+      description: "Flat rate once you consistently close twenty qualified deals a month",
       priceText: "$399/month",
       features: [
         "Includes the first 20 qualified leads each month",
         "$45 per additional lead after your included quota",
-        "Dedicated revenue strategist and weekly playbook reviews",
+        "Weekly check-ins with a revenue strategist",
         "Pipeline analytics, CRM syncs, and SLA monitoring",
       ],
       featured: true,
@@ -42,7 +42,7 @@ export const PricingGrid = () => {
     },
     {
       title: "Enterprise Revenue Desk",
-      description: "Custom automations, routing, and compliance for large teams",
+      description: "Custom automations, routing, and compliance for larger teams",
       priceText: "Custom pricing",
       features: [
         "Multi-brand knowledge hubs and territory controls",
@@ -54,7 +54,7 @@ export const PricingGrid = () => {
     },
     {
       title: "Partner Program",
-      description: "For agencies and consultants who want to resell vatas",
+      description: "For agencies and consultants who resell vatas to their clients",
       priceText: "Apply to join",
       features: [
         "Revenue share on every lead closed",

--- a/components/testimonials/index.tsx
+++ b/components/testimonials/index.tsx
@@ -16,9 +16,9 @@ export const Testimonials = () => {
         <FeatureIconContainer className="flex justify-center items-center overflow-hidden">
           <TbLocationBolt className="h-6 w-6 text-cyan-500" />
         </FeatureIconContainer>
-        <Heading className="pt-4">Loved by revenue teams worldwide</Heading>
+        <Heading className="pt-4">Teams using vatas to keep deals moving</Heading>
         <Subheading>
-          Vatas keep go-to-market teams closing while AI handles the grind.
+          Real revenue leaders sharing how autonomous sellers free them up to close.
         </Subheading>
       </div>
 

--- a/components/tools.tsx
+++ b/components/tools.tsx
@@ -19,9 +19,9 @@ export const Tools = () => {
   const content = [
     {
       icon: <IconSocial className="h-8 w-8 text-secondary" />,
-      title: "Connect your social graph",
+      title: "Link the places you sell",
       description:
-        "Authorize LinkedIn, Reddit, X, Slack, and email so vatas surface warm conversations automatically.",
+        "Authorize LinkedIn, Reddit, X, Slack, and email so vatas surface active conversations without you hunting for them.",
       content: (
         <ImageContainer>
           <Iphone videoSrc="/videos/social.mp4" scale="sm" />
@@ -30,9 +30,9 @@ export const Tools = () => {
     },
     {
       icon: <IconMailForward className="h-8 w-8 text-secondary" />,
-      title: "Live inbox oversight",
+      title: "Review the inbox in real time",
       description:
-        "Review outreach, approve replies, and jump in the moment a vata needs you.",
+        "Read every outreach, approve replies, and jump in the moment a vata flags a thread.",
       content: (
         <ImageContainer>
           <Iphone imageSrc="/images/inbox.png" scale="md" />
@@ -41,9 +41,9 @@ export const Tools = () => {
     },
     {
       icon: <IconTerminal className="h-8 w-8 text-secondary" />,
-      title: "Knowledge hub sync",
+      title: "Sync your knowledge base",
       description:
-        "Feed recordings, docs, and analytics so vatas learn your product, objections, and differentiators.",
+        "Upload recordings, docs, and analytics so vatas learn your product, objections, and differentiators.",
       content: (
         <ImageContainer>
           <Iphone videoSrc="/videos/hub.mp4" scale="sm" />
@@ -52,9 +52,9 @@ export const Tools = () => {
     },
     {
       icon: <IconTool className="h-8 w-8 text-secondary" />,
-      title: "Revenue analytics",
+      title: "Track the numbers",
       description:
-        "Track sourced pipeline, win rates, and response speed across every vata from one dashboard.",
+        "Watch sourced pipeline, win rates, and response times for every vata from one dashboard.",
       content: (
         <ImageContainer>
           <BlurImage
@@ -111,12 +111,9 @@ export const Tools = () => {
         <FeatureIconContainer className="flex justify-center items-center overflow-hidden">
           <IconTool className="h-6 w-6 text-cyan-500" />
         </FeatureIconContainer>
-        <Heading className="mt-4">
-          Every workflow in one revenue command center
-        </Heading>
+        <Heading className="mt-4">One place to run the vatas</Heading>
         <Subheading>
-          Launch vatas, train them once, stay in the inbox, and track pipeline
-          impact without juggling tools.
+          Launch them, train them once, stay on top of the inbox, and watch the pipeline without switching tools.
         </Subheading>
       </div>
       <StickyScroll content={content} />


### PR DESCRIPTION
## Summary
- rewrite homepage feature, tools, testimonial, pricing, and CTA copy to explain capabilities without marketing language
- update FAQ, client carousel, and pricing blurb text to match the more direct tone across the page

## Testing
- npm run dev *(fails to fetch external assets due to sandbox network restrictions, server still starts)*

------
https://chatgpt.com/codex/tasks/task_e_68d8993419f08330acbdd96631967bb9