### PR TITLE
Use Paygeon font for site headings

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -17,6 +17,19 @@ body {
   color: rgb(var(--foreground-rgb));
 }
 
+@layer base {
+  body {
+    @apply font-sans;
+  }
+
+  h1,
+  h2,
+  h3,
+  .font-heading {
+    font-family: var(--font-paygeon), var(--font-inter), sans-serif;
+  }
+}
+
 @layer utilities {
   .text-balance {
     text-wrap: balance;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import { Inter } from "next/font/google";
+import localFont from "next/font/local";
 import { cn } from "@/lib/utils";
 import { ViewTransitions } from "next-view-transitions";
 import type { Viewport } from "next";
@@ -27,6 +28,13 @@ const inter = Inter({
   subsets: ["latin"],
   display: "swap",
   weight: ["400", "500", "600", "700", "800", "900"],
+  variable: "--font-inter",
+});
+
+const paygeon = localFont({
+  src: "../public/fonts/Paygeon.otf",
+  display: "swap",
+  variable: "--font-paygeon",
 });
 
 export default function RootLayout({
@@ -39,8 +47,9 @@ export default function RootLayout({
       <html lang="en">
         <body
           className={cn(
-            inter.className,
-            "bg-charcoal antialiased h-full w-full"
+            inter.variable,
+            paygeon.variable,
+            "bg-charcoal antialiased h-full w-full font-sans"
           )}
         >
           <NavBar />

--- a/components/heading.tsx
+++ b/components/heading.tsx
@@ -27,7 +27,7 @@ export const Heading = ({
     <Tag
       className={cn(
         "text-3xl md:text-5xl md:leading-tight max-w-5xl mx-auto text-center tracking-tight",
-        "font-medium",
+        "font-medium font-heading",
         "bg-clip-text text-transparent bg-gradient-to-b from-neutral-800 via-white to-white",
         sizeVariants[size],
         className

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -11,6 +11,10 @@ const config: Config = {
   ],
   theme: {
     extend: {
+      fontFamily: {
+        sans: ["var(--font-inter)", "system-ui", "sans-serif"],
+        heading: ["var(--font-paygeon)", "var(--font-inter)", "sans-serif"],
+      },
       colors: {
         charcoal: "#08090A",
         secondary: "#39C3EF",


### PR DESCRIPTION
## Summary
- load the Paygeon typeface alongside Inter in the root layout
- configure Tailwind and global styles so primary headings use the Paygeon font
- update the shared Heading component to adopt the new heading font utility

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9866eeff88330816affe9f58ce3b8