### PR TITLE
Update marketing copy for new $5 lead and $399/year pricing

### DIFF
--- a/app/(marketing)/page.tsx
+++ b/app/(marketing)/page.tsx
@@ -28,7 +28,7 @@ export default function Home() {
         </FeatureIconContainer>
         <Heading className="pt-4">Results-based pricing</Heading>
         <Subheading>
-          Pay only for the qualified opportunities vatas close, with a flat
+          Pay $5 for every qualified opportunity vatas close, with a $399/year
           subscription once you pass twenty wins a month.
         </Subheading>
         <PricingGrid />

--- a/app/(marketing)/pricing/page.tsx
+++ b/app/(marketing)/pricing/page.tsx
@@ -12,7 +12,7 @@ import { Metadata } from "next";
 export const metadata: Metadata = {
   title: "Pricing | Vatas",
   description:
-    "Only pay when Vatas deliver qualified leads, or lock in a subscription once you consistently close 20+ new deals a month.",
+    "Only pay $5 when Vatas deliver qualified leads, or lock in a $399/year subscription once you consistently close 20+ new deals a month.",
   openGraph: {
     images: ["/banner.png"],
   },

--- a/components/faqs.tsx
+++ b/components/faqs.tsx
@@ -50,7 +50,7 @@ const questions = [
     id: 8,
     title: "How does pricing work?",
     description:
-      "Pay $50 per qualified lead monthly, or choose the $399/month subscription past twenty wins.",
+      "Pay $5 per qualified lead, or choose the $399/year subscription once you're scaling past twenty wins.",
   },
   {
     id: 9,

--- a/components/features/index.tsx
+++ b/components/features/index.tsx
@@ -75,7 +75,7 @@ export const Features = () => {
             </CardSkeletonContainer>
             <CardTitle>Pay-for-results billing</CardTitle>
             <CardDescription>
-              Get one monthly invoice tied to qualified deals, starting at $50 per lead.
+              Get one invoice tied to qualified deals, starting at $5 per lead.
             </CardDescription>
           </Card>
         </div>

--- a/components/pricing-grid.tsx
+++ b/components/pricing-grid.tsx
@@ -18,7 +18,7 @@ export const PricingGrid = () => {
     {
       title: "Pay for Results",
       description: "Only pay when a vata closes a qualified lead",
-      priceText: "$50 per qualified lead",
+      priceText: "$5 per qualified lead",
       features: [
         "No platform fees or retainers",
         "Verified buyer identity, intent, and contact info",
@@ -30,10 +30,10 @@ export const PricingGrid = () => {
     {
       title: "Growth Subscription",
       description: "Predictable pricing for teams closing 20+ new deals each month",
-      priceText: "$399/month",
+      priceText: "$399/year",
       features: [
-        "Includes the first 20 qualified leads each month",
-        "$45 per additional lead after your included quota",
+        "Includes the first 120 qualified leads each year",
+        "$5 per additional lead after your included quota",
         "Dedicated revenue strategist and weekly playbook reviews",
         "Pipeline analytics, CRM syncs, and SLA monitoring",
       ],


### PR DESCRIPTION
## Summary
- update the pricing grid to reflect the $5 per qualified lead rate and the $399/year subscription plan
- refresh marketing, FAQ, and feature copy to mention the new pricing structure
- adjust pricing page metadata so previews highlight the updated pricing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e19137afec8330b194b4baf09799fe